### PR TITLE
fix/sacar#_del_logo_track_t_home

### DIFF
--- a/tt-web/src/components/logo/Logo.jsx
+++ b/tt-web/src/components/logo/Logo.jsx
@@ -7,7 +7,7 @@ import styles from "./Logo.module.css";
 
 export default function Logo () {
     return (
-        <Link href="/#" className={`${styles.logo} center `}>
+        <Link href="/" className={`${styles.logo} center `}>
             <div className={`${styles.container} center `}>
                 <Image width={'auto'} height={50} src={logoTravel} alt="Logo" />
                 <h1>Track Travel</h1>


### PR DESCRIPTION
se quita el # del logo de valija en home

![image](https://user-images.githubusercontent.com/89527425/226944996-56666a77-5eaf-4356-b8ad-0dc95e9f1bc9.png)
